### PR TITLE
add agent options, swap q-io/http for request-promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var config = require('ih-config');
-var Promise = require('bluebird');
 var log = require('ih-log');
 var rp = require('request-promise');
 var _ = require('lodash');
@@ -117,12 +116,10 @@ function scrollToEnd (index, type, body, ttlInMin, noScan) {
 * @param  {string} scrollId    Elasticsearch scroll_id to get the next page for.
 * @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
 */
-function pageScroll(scrollId, rawData){
+function pageScroll(scrollId){
   var path = '/_search/scroll?scroll=' + TTL_IN_MIN + 'm&scroll_id=' + (scrollId || '') + filterPath;
-  var parse = rawData ? readRawBytes : parseElasticResponse;
   profileScroll();
-  return Promise.resolve(httpGet(path))
-    .then(parse)
+  return httpGet(path)
     .tap(profileScroll);
 
   function profileScroll(){
@@ -186,22 +183,26 @@ function httpGet(path) {
 function httpPost(path, body, logMessage) {
   logMessage = typeof logMessage !== 'undefined' ? logMessage : '';
   log.debug('%s Executing elastic query route: [%s] body: %s', logMessage, path, body);
-  const options = buildHttpOptions('POST', path);
+  const options = buildHttpOptions('POST', path, body);
   return rp(options);
 }
 
-function buildHttpOptions(method, path) {
+function buildHttpOptions(method, path, body) {
   const options = {
       uri: buildUri(path),
       method: method,
       headers: headers,
-      transform: parseElasticResponse,
+      transform: parseElasticResponse
   };
 
   if(config.get('elastic:ca')){
     options.agentOptions = {
       ca: config.get('elastic:ca')
     }
+  }
+
+  if(method === 'POST'){
+    options.body = body;
   }
 
   return options;
@@ -212,7 +213,7 @@ function buildUri(path){
   return protocol.concat(config.get('elastic:server')).concat(':').concat(config.get('elastic:port')).concat('/').concat(path);
 }
 
-function parseElasticResponse(response, profileMessage) {
+function parseElasticResponse(response, profileMessage = 'Parse response') {
   if (profileMessage) {
     log.debug(profileMessage + ' READ');
   }
@@ -222,11 +223,4 @@ function parseElasticResponse(response, profileMessage) {
   if (profileMessage) {
     log.debug(profileMessage + ' PARSE');
   }
-}
-
-function readRawBytes(response) {
-  return response.body.read()
-  .then(function(response) {
-    return response.toString();
-  });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,9 +218,11 @@ function parseElasticResponse(response, profileMessage = 'Parse response') {
     log.debug(profileMessage + ' READ');
   }
 
-  return JSON.parse(response);
+  const res = JSON.parse(response);
 
   if (profileMessage) {
     log.debug(profileMessage + ' PARSE');
   }
+
+  return res;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 var config = require('ih-config');
 var Promise = require('bluebird');
 var log = require('ih-log');
-var http = require('q-io/http');
+var rp = require('request-promise');
 var _ = require('lodash');
 var uuid = require('uuid');
 
@@ -13,10 +13,10 @@ var TTL_IN_MIN = 3;
 var filterPath ='&filter_path=_scroll_id,took,hits.hits,hits.hits._id,hits.hits._source,hits.total,aggregations.*';
 
 var headers = {
-    "Content-Type": "application/json"
+  "Content-Type": "application/json"
 };
 if (config.get('elastic:username') && config.get('elastic:password')){
-    headers["authorization"] = 'Basic ' + new Buffer(config.get('elastic:username') + ':' + config.get('elastic:password')).toString('base64')
+  headers["authorization"] = 'Basic ' + new Buffer(config.get('elastic:username') + ':' + config.get('elastic:password')).toString('base64')
 }
 
 module.exports = {
@@ -30,14 +30,14 @@ module.exports = {
 };
 
 /**
- * Sends a query to elasticsearch _search endpoint for given index and type.
- * @param  {string} index       Elasticsearch index used.
- * @param  {string} type        Elasticsearch type to query.
- * @param  {string} body        Elasticsearch query body. String-form JSON.
- * @param  {string} queryString Querystring to append to _search. Include the '?'.
- * @param  {string} logMessage  Optional logging message.
- * @return {Promise(object)}    Parsed JSON response from elastic.
- */
+* Sends a query to elasticsearch _search endpoint for given index and type.
+* @param  {string} index       Elasticsearch index used.
+* @param  {string} type        Elasticsearch type to query.
+* @param  {string} body        Elasticsearch query body. String-form JSON.
+* @param  {string} queryString Querystring to append to _search. Include the '?'.
+* @param  {string} logMessage  Optional logging message.
+* @return {Promise(object)}    Parsed JSON response from elastic.
+*/
 function executeSearch(index, type, body, logMessage, queryString) {
   var searchId = uuid.v1();
   queryString = (queryString || '') + (queryString ? '&' : '?') + 'request_cache=true' + filterPath;
@@ -45,7 +45,6 @@ function executeSearch(index, type, body, logMessage, queryString) {
   var profileMessage = 'ES ' + index + ' _search ' + logMessage + ' ' + searchId;
   profileSearch();
   return httpPost(path, body, logMessage)
-    .then(function(resp){return parseElasticResponse(resp, profileMessage);})
     .then(profileSearch);
 
   function profileSearch(resp){
@@ -58,32 +57,32 @@ function executeSearch(index, type, body, logMessage, queryString) {
 }
 
 /**
- * Sends a count query to elasticsearch _search endpoint for given index and type.
- * Automatically appends ?search_type=count.
- * *** Will include any aggs that are part of the query. ***
- * @param  {string} index       Elasticsearch index used.
- * @param  {string} type        Elasticsearch type to query.
- * @param  {string} body        Elasticsearch query body. String-form JSON.
- * @param {string} logMessage   optional log message to identify this query in the logs.
- * @return {Promise(object)}    Parsed JSON response from elastic.
- */
+* Sends a count query to elasticsearch _search endpoint for given index and type.
+* Automatically appends ?search_type=count.
+* *** Will include any aggs that are part of the query. ***
+* @param  {string} index       Elasticsearch index used.
+* @param  {string} type        Elasticsearch type to query.
+* @param  {string} body        Elasticsearch query body. String-form JSON.
+* @param {string} logMessage   optional log message to identify this query in the logs.
+* @return {Promise(object)}    Parsed JSON response from elastic.
+*/
 function executeCount(index, type, body, logMessage) {
   logMessage = logMessage || 'executeCount';
   return executeSearch(index, type, body, logMessage, '?search_type=count');
 }
 
 /**
- * Sends a query to elasticsearch _search endpoint for given index and type.
- * Automatically appends ?scroll=1m&search_type=scan unless noScan is set.
- *
- * *** Will include any aggs that are part of the query. ***
- * @param  {string} index       Elasticsearch index used.
- * @param  {string} type        Elasticsearch type to query.
- * @param  {string} body        Elasticsearch query body. String-form JSON.
- * @param  {int} ttlInMin   Time for scroll to live between requests in minutes.
- * @param  {boolean} noScan     If true, don't use scan. Defaults to false.
- * @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
- */
+* Sends a query to elasticsearch _search endpoint for given index and type.
+* Automatically appends ?scroll=1m&search_type=scan unless noScan is set.
+*
+* *** Will include any aggs that are part of the query. ***
+* @param  {string} index       Elasticsearch index used.
+* @param  {string} type        Elasticsearch type to query.
+* @param  {string} body        Elasticsearch query body. String-form JSON.
+* @param  {int} ttlInMin   Time for scroll to live between requests in minutes.
+* @param  {boolean} noScan     If true, don't use scan. Defaults to false.
+* @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
+*/
 function executeScroll(index, type, body, ttlInMin, noScan) {
   TTL_IN_MIN = ttlInMin || TTL_IN_MIN;
   var ttlString = TTL_IN_MIN + 'm';
@@ -95,16 +94,16 @@ function executeScroll(index, type, body, ttlInMin, noScan) {
 }
 
 /**
- * Wraps scroll/scan methods.
- *
- * *** Will include any aggs that are part of the query. ***
- * @param  {string} index       Elasticsearch index used.
- * @param  {string} type        Elasticsearch type to query.
- * @param  {string} body        Elasticsearch query body. String-form JSON.
- * @param  {int} ttlInMin       Time for scroll to live between requests in minutes.
- * @param  {boolean} noScan     If true, don't use scan. Defaults to false.
- * @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
- */
+* Wraps scroll/scan methods.
+*
+* *** Will include any aggs that are part of the query. ***
+* @param  {string} index       Elasticsearch index used.
+* @param  {string} type        Elasticsearch type to query.
+* @param  {string} body        Elasticsearch query body. String-form JSON.
+* @param  {int} ttlInMin       Time for scroll to live between requests in minutes.
+* @param  {boolean} noScan     If true, don't use scan. Defaults to false.
+* @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
+*/
 function scrollToEnd (index, type, body, ttlInMin, noScan) {
   var recurseScroll = _.curry(scroll)([]);
   return executeScroll(index, type, body, ttlInMin, noScan)
@@ -112,12 +111,12 @@ function scrollToEnd (index, type, body, ttlInMin, noScan) {
 }
 
 /**
- * Gets the scroll results for the provided scrollId
- *
- * *** Will include any aggs that are part of the query. ***
- * @param  {string} scrollId    Elasticsearch scroll_id to get the next page for.
- * @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
- */
+* Gets the scroll results for the provided scrollId
+*
+* *** Will include any aggs that are part of the query. ***
+* @param  {string} scrollId    Elasticsearch scroll_id to get the next page for.
+* @return {Promise(object)}    Parsed JSON response from elastic. -Includes _scroll_id for pageScroll calls.
+*/
 function pageScroll(scrollId, rawData){
   var path = '/_search/scroll?scroll=' + TTL_IN_MIN + 'm&scroll_id=' + (scrollId || '') + filterPath;
   var parse = rawData ? readRawBytes : parseElasticResponse;
@@ -139,13 +138,13 @@ function parseScrollId(res) {
 }
 
 /**
- * Executes a basic GET request at the given path.  Search requests will throw an error.
- * Meant for reaching admin endpoints such as '/', the cat apis, the cluster apis, etc.
- *
- * @param {string} path       The endpoint path
- * @param {boolean} verbose   Specifies whether or not to add '?v' to request, which enables a verbose response on any request
- * @return {Promise(object)}  Parsed JSON response from elastic
- */
+* Executes a basic GET request at the given path.  Search requests will throw an error.
+* Meant for reaching admin endpoints such as '/', the cat apis, the cluster apis, etc.
+*
+* @param {string} path       The endpoint path
+* @param {boolean} verbose   Specifies whether or not to add '?v' to request, which enables a verbose response on any request
+* @return {Promise(object)}  Parsed JSON response from elastic
+*/
 function executeBasicGet(path, verbose) {
   if (path.toLowerCase().includes('_search')) {
     throw new Error('Basic Get cannot perform search.');
@@ -160,9 +159,8 @@ function executeBasicGet(path, verbose) {
 }
 
 /**
- * Private - Not exported below this line.
- */
-
+* Private - Not exported below this line.
+*/
 function scroll(results, res){
   results = results.concat(res.hits.hits);
   var curriedScroll = _.curry(scroll)(results);
@@ -181,50 +179,49 @@ function scroll(results, res){
 
 function httpGet(path) {
   log.debug('Executing elastic get route: ...[%s]', path.substr(path.length-5, 5));
-  return http.request({
-    host: config.get('elastic:server'),
-    port: config.get('elastic:port'),
-    path: path,
-    method: 'GET',
-    headers: headers
-  });
+  const options = buildHttpOptions('GET', path);
+  return rp(options);
 }
-
 
 function httpPost(path, body, logMessage) {
   logMessage = typeof logMessage !== 'undefined' ? logMessage : '';
   log.debug('%s Executing elastic query route: [%s] body: %s', logMessage, path, body);
-  return http.request({
-    host: config.get('elastic:server'),
-    port: config.get('elastic:port'),
-    path: path,
-    method: 'POST',
-    body: [body],
-    headers: headers
-  });
+  const options = buildHttpOptions('POST', path);
+  return rp(options);
+}
+
+function buildHttpOptions(method, path) {
+  const options = {
+      uri: buildUri(path),
+      method: method,
+      headers: headers,
+      transform: parseElasticResponse,
+  };
+
+  if(config.get('elastic:ca')){
+    options.agentOptions = {
+      ca: config.get('elastic:ca')
+    }
+  }
+
+  return options;
+}
+
+function buildUri(path){
+  const protocol = (config.get('elastic:ca') ? 'https://' : 'http://');
+  return protocol.concat(config.get('elastic:server')).concat(':').concat(config.get('elastic:port')).concat('/').concat(path);
 }
 
 function parseElasticResponse(response, profileMessage) {
   if (profileMessage) {
     log.debug(profileMessage + ' READ');
   }
-  return response.body.read()
-  .then(function(body) {
-    if (profileMessage) {
-      log.debug(profileMessage + ' READ');
-    }
-    if (profileMessage) {
-      log.debug(profileMessage + ' PARSE' );
-    }
-    var str = body.toString('utf-8');
-    //log.debug('ES response from %s: %s', profileMessage, str);
-    //NOTE: eval is only used here because we trust the source (Elasticsearch)
-    var resp = eval('(' + str + ')'); // jshint ignore:line
-    if (profileMessage) {
-      log.debug(profileMessage + ' PARSE');
-    }
-    return resp;
-  });
+
+  return JSON.parse(response);
+
+  if (profileMessage) {
+    log.debug(profileMessage + ' PARSE');
+  }
 }
 
 function readRawBytes(response) {
@@ -232,16 +229,4 @@ function readRawBytes(response) {
   .then(function(response) {
     return response.toString();
   });
-}
-
-function getHash(s) {
-  var hash = 0,
-    i, char;
-  if (s.length === 0) return hash;
-  for (i = 0; i < s.length; i++) {
-    char = s.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash |= 0; // Convert to 32bit integer
-  }
-  return hash;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ih-elastic-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Influence Health basic nodejs elasticsearch client that hooks into ih-log and ih-config",
   "main": "./lib/index.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ih-config": "~1.0.0",
     "ih-log": "~1.0.0",
     "bluebird": "~3.4.5",
-    "q-io": "~1.13.2",
+    "request-promise": "^4.2.2",
     "lodash": "~4.16.6",
     "uuid": "~2.0.3"
   }


### PR DESCRIPTION
This PR is to support SSL authentication based on IH elasticsearch config. q-io made the passing of specific http options difficult, so swapped it out for request-promise under the hood. 